### PR TITLE
Indicate that Teleport supports Github SSO in the OSS version

### DIFF
--- a/_vendors_bad/goteleport.yaml
+++ b/_vendors_bad/goteleport.yaml
@@ -2,6 +2,8 @@
 base_pricing: 15
 currency: USD
 name: Teleport
+free_sso_providers:
+  - Github
 pricing_scheme: per user/month
 pricing_sources:
   - https://goteleport.com/pricing/


### PR DESCRIPTION
Teleport offers integration with Github SSO as part of its Community/OSS version.

Docs: https://goteleport.com/docs/access-controls/sso/github-sso/