### PR TITLE
Update readme.yaml to reflect current pricing

### DIFF
--- a/_vendors_bad/readme.yaml
+++ b/_vendors_bad/readme.yaml
@@ -5,6 +5,6 @@ name: ReadMe
 pricing_scheme: per project/month
 pricing_sources:
   - https://readme.com/pricing
-sso_pricing: 2000
-updated_at: 2020-10-30
+sso_pricing: 3000
+updated_at: 2025-01-15
 vendor_url: https://readme.com


### PR DESCRIPTION
SSO now only available at the Enterprise tier, which is priced at "$3000+" according to readme.com/pricing